### PR TITLE
Prevent compiler from optimizing security checks for libbt-vendor

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -24,7 +24,9 @@ ifeq ($(BOARD_HAVE_BLUETOOTH_INTEL_ICNV), true)
 include $(CLEAR_VARS)
 
 LOCAL_CPP_EXTENSION := .cc
-
+LOCAL_CPPFLAGS := -fno-strict-overflow \
+                  -fno-delete-null-pointer-checks \
+                  -fwrapv
 LOCAL_SRC_FILES := \
         bt_vendor.cc
 


### PR DESCRIPTION
Adding compiler flags to prevent optimization on security checks

Tracked-On: OAM-89011
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>