### PR TITLE
Revert "Prevent compiler from optimizing security checks for libbt-ve…

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -24,9 +24,7 @@ ifeq ($(BOARD_HAVE_BLUETOOTH_INTEL_ICNV), true)
 include $(CLEAR_VARS)
 
 LOCAL_CPP_EXTENSION := .cc
-LOCAL_CPPFLAGS := -fno-strict-overflow \
-                  -fno-delete-null-pointer-checks \
-                  -fwrapv
+
 LOCAL_SRC_FILES := \
         bt_vendor.cc
 


### PR DESCRIPTION
…ndor"

This reverts commit 84782c46782fba870fa3d76f8e8ab4a601c33c3a.

Tracked-On: OAM-89568
Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>