### PR TITLE
Add compiler flags for libbt-vendor-intel

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -24,6 +24,14 @@ ifeq ($(BOARD_HAVE_BLUETOOTH_INTEL_ICNV), true)
 include $(CLEAR_VARS)
 
 LOCAL_CPP_EXTENSION := .cc
+LOCAL_CPPFLAGS := -fno-strict-overflow \
+                  -fwrapv \
+                  -D_FORTIFY_SOURCE=2 \
+                  -fstack-protector-strong \
+                  -Wno-conversion-null \
+                  -Wnull-dereference \
+                  -Werror \
+                  -Warray-bounds
 
 LOCAL_SRC_FILES := \
         bt_vendor.cc


### PR DESCRIPTION
compiler options added to make sure null pointer deference
length check, buffer overflow/underflow is handled properly

Tracked-On: OAM-89564
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>