### PR TITLE
Add Compiler flags for libbt-vendor-intel

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -32,7 +32,9 @@ LOCAL_CPPFLAGS := -fno-strict-overflow \
                   -Wno-conversion-null \
                   -Wnull-dereference \
                   -Werror \
-                  -Warray-bounds
+                  -Warray-bounds \
+                  -Wformat -Wformat-security \
+                  -Werror=format-security
 LOCAL_SRC_FILES := \
         bt_vendor.cc
 


### PR DESCRIPTION
Add compiler flags to to avoid uncontrolled format strings

Tracked-On: OAM-90305
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>