### PR TITLE
Moving Android T bring up patches to github

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -24,8 +24,7 @@ ifeq ($(BOARD_HAVE_BLUETOOTH_INTEL_ICNV), true)
 include $(CLEAR_VARS)
 
 LOCAL_CPP_EXTENSION := .cc
-LOCAL_CPPFLAGS := -fno-strict-overflow \
-                  -fno-delete-null-pointer-checks \
+LOCAL_CPPFLAGS := -fno-delete-null-pointer-checks \
                   -fwrapv \
                   -D_FORTIFY_SOURCE=2 \
                   -fstack-protector-strong \

--- a/Android.mk
+++ b/Android.mk
@@ -39,7 +39,7 @@ LOCAL_SRC_FILES := \
         bt_vendor.cc
 
 LOCAL_C_INCLUDES := \
-        $(TOP_DIR)system/bt/hci/include
+        $(TOP_DIR)packages/modules/Bluetooth/system/hci/include
 
 LOCAL_SHARED_LIBRARIES := \
         liblog \


### PR DESCRIPTION
Port the bsp_diff patches introduced to fix Android-T build errors to corresponding github projects