### PR TITLE
Fix Bluetooth failure due to invalid write len

### DIFF
--- a/bt_vendor.cc
+++ b/bt_vendor.cc
@@ -174,7 +174,7 @@ static int bt_vendor_wait_hcidev(void) {
   ev.len = 0;
 
   ssize_t wrote;
-  wrote = write(fd, &ev, sizeof(mgmt_pkt));
+  wrote = write(fd, &ev, sizeof(mgmt_pkt) - MGMT_EV_SIZE_MAX);
   if (wrote != 6) {
     ALOGE("Unable to write mgmt command: %s", strerror(errno));
     ret = -1;


### PR DESCRIPTION
Correct length will be provided for writing mgmt command.

Tracked-On: OAM-107366