### PR TITLE
Fix bt static analysis issue

### DIFF
--- a/bt_vendor.cc
+++ b/bt_vendor.cc
@@ -169,6 +169,7 @@ static int bt_vendor_wait_hcidev(void) {
   fds[0].events = POLLIN;
 
   /* Read Controller Index List Command */
+  memset(&ev, 0, sizeof(ev));
   ev.opcode = MGMT_OP_INDEX_LIST;
   ev.index = HCI_DEV_NONE;
   ev.len = 0;


### PR DESCRIPTION
Fix Uninitialized scalar variable in bt_vendor.
Validated the BT on/off after pushing the .so files. BT is working fine.

Tracked-On: OAM-116732